### PR TITLE
add instructions CMP, ADC, and SBC to emulator

### DIFF
--- a/src/emulator/cpu.rs
+++ b/src/emulator/cpu.rs
@@ -221,7 +221,7 @@ impl CPU {
 #[cfg(test)]
 mod test {
     use crate::{
-        emulator::cpu::{CPU, FLAG_CARRY, FLAG_ZERO, REG_LR, REG_PC, REG_SP},
+        emulator::cpu::{CPU, FLAG_CARRY, FLAG_ZERO, REG_LR, REG_PC},
         utils::bit_utils::{BitSetUtils, BitUtils},
     };
 

--- a/src/emulator/cpu.rs
+++ b/src/emulator/cpu.rs
@@ -300,7 +300,7 @@ mod test {
     fn carry_intructions() {
         let mut cpu = CPU::default();
 
-        cpu.cpsr.set_bit(FLAG_CARRY, true);
+        cpu.cpsr = cpu.cpsr.set_bit(FLAG_CARRY, true);
         cpu.regs[1] = 1;
         cpu.regs[2] = 1;
 
@@ -309,7 +309,7 @@ mod test {
 
         cpu.regs[1] = 1;
         cpu.regs[2] = 1;
-        cpu.cpsr.set_bit(FLAG_CARRY, false);
+        cpu.cpsr = cpu.cpsr.set_bit(FLAG_CARRY, false);
 
         cpu.run_instr(0xE0A11002);
         println!("{0:?}", cpu.regs);

--- a/src/emulator/cpu.rs
+++ b/src/emulator/cpu.rs
@@ -198,6 +198,7 @@ impl CPU {
                 }
             }
             0b0101 => self.regs[rd as usize] = rn_value + operand + self.cpsr.at_bit(FLAG_CARRY),
+            0b0110 => self.regs[rd as usize] = rn_value - operand + self.cpsr.at_bit(FLAG_CARRY) - 1,
             0b1010 => {
                 // CMP Instruction
                 let value = rn_value as i32 - operand as i32;
@@ -314,5 +315,13 @@ mod test {
         cpu.run_instr(0xE0A11002);
         println!("{0:?}", cpu.regs);
         assert_eq!(cpu.regs[1], 2);
+
+        cpu.run_instr(0xE0C11002);
+        assert_eq!(cpu.regs[1], 0);
+
+        cpu.regs[1] = 1;
+        cpu.regs[2] = 1;
+        cpu.cpsr = cpu.cpsr.set_bit(FLAG_CARRY, true);
+        assert_eq!(cpu.regs[1], 1);
     }
 }

--- a/src/emulator/cpu.rs
+++ b/src/emulator/cpu.rs
@@ -198,11 +198,12 @@ impl CPU {
                 }
             }
             0b1010 => {
+                // CMP Instruction
                 let value = rn_value as i32 - operand as i32;
-                self.cpsr.set_bit(FLAG_SIGN, value < 0);
-                self.cpsr.set_bit(FLAG_ZERO, value == 0);
-                self.cpsr.set_bit(FLAG_CARRY, rn_value >= operand);
-                self.cpsr.set_bit(
+                self.cpsr = self.cpsr.set_bit(FLAG_SIGN, value < 0);
+                self.cpsr = self.cpsr.set_bit(FLAG_ZERO, rn_value == operand);
+                self.cpsr =  self.cpsr.set_bit(FLAG_CARRY, rn_value >= operand);
+                self.cpsr = self.cpsr.set_bit(
                     FLAG_OVERFLOW,
                     ((rn_value ^ operand) & (rn_value ^ value as u32)) >> 31 == 1,
                 );
@@ -286,7 +287,6 @@ mod test {
         cpu.run_instr(0xE1500001);
         assert_eq!(cpu.cpsr.at_bit(FLAG_ZERO), 1);
 
-        cpu.regs[1] = 1;
         cpu.regs[2] = 2;
         cpu.run_instr(0xE1510002);
         assert_eq!(cpu.cpsr.at_bit(FLAG_ZERO), 0);

--- a/src/emulator/cpu.rs
+++ b/src/emulator/cpu.rs
@@ -1,6 +1,9 @@
 use std::{fs::File, io::Read, mem::offset_of};
 
-use crate::{emulator::bus::Bus, utils::bit_utils::BitUtils};
+use crate::{
+    emulator::bus::Bus,
+    utils::bit_utils::{BitSetUtils, BitUtils},
+};
 
 const REG_SP: usize = 13;
 const REG_LR: usize = 14;
@@ -194,6 +197,16 @@ impl CPU {
                     todo!("Implement SUBS, ADDS, and MOVS respectively");
                 }
             }
+            0b1010 => {
+                let value = rn_value as i32 - operand as i32;
+                self.cpsr.set_bit(FLAG_SIGN, value < 0);
+                self.cpsr.set_bit(FLAG_ZERO, value == 0);
+                self.cpsr.set_bit(FLAG_CARRY, rn_value >= operand);
+                self.cpsr.set_bit(
+                    FLAG_OVERFLOW,
+                    ((rn_value ^ operand) & (rn_value ^ value as u32)) >> 31 == 1,
+                );
+            }
             _ => {
                 unimplemented!()
             }
@@ -205,7 +218,7 @@ impl CPU {
 
 #[cfg(test)]
 mod test {
-    use crate::emulator::cpu::{CPU, REG_LR, REG_PC, REG_SP};
+    use crate::{emulator::cpu::{CPU, FLAG_ZERO, REG_LR, REG_PC, REG_SP}, utils::bit_utils::BitUtils};
 
     #[test]
     fn data_processing() {
@@ -263,4 +276,19 @@ mod test {
         assert_eq!(cpu.read_ram_u32(0x03000026), 0x69420);
     }
 
+    #[test]
+    fn cmp_tests() {
+        let mut cpu = CPU::default();
+        
+        cpu.regs[0] = 1;
+        cpu.regs[1] = 1;
+
+        cpu.run_instr(0xE1500001);
+        assert_eq!(cpu.cpsr.at_bit(FLAG_ZERO), 1);
+
+        cpu.regs[1] = 1;
+        cpu.regs[2] = 2;
+        cpu.run_instr(0xE1510002);
+        assert_eq!(cpu.cpsr.at_bit(FLAG_ZERO), 0);
+    }
 }

--- a/src/utils/bit_utils.rs
+++ b/src/utils/bit_utils.rs
@@ -12,7 +12,7 @@ impl BitSetUtils for u32 {
         if value {
             (1 << pos) | self
         } else {
-            !(1 << pos) & self
+            (!(1 << pos)) & self
         }
     }
 }


### PR DESCRIPTION
- **feat: add cmp**
- **fix: add modifications of cpsr**
- **feat: add adc**
- **chore: remove unused imports**
- **feat: fix adc instruction test**
- **feat: add SBC**
